### PR TITLE
Ref_aa_seq_np, whitespace, and Mugration

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -41,7 +41,6 @@ def translate_vcf_feature(sequences, ref, feature):
 
     refNuc = str(feature.extract( SeqRecord(seq=Seq(ref)) ).seq)
     ref_aa_seq = safe_translate(refNuc)
-    ref_aa_seq_np = np.array(list(ref_aa_seq), 'S1')
     prot['reference'] = ref_aa_seq
 
     start = int(feature.location.start)
@@ -67,7 +66,7 @@ def translate_vcf_feature(sequences, ref, feature):
         aaRepLocsFinal = {}
         #remove if is a synonymous mutation!
         for key,val in aaRepLocs.iteritems():
-            if ref_aa_seq_np[key] != val:
+            if ref_aa_seq[key] != val:
                 aaRepLocsFinal[key] = val
                 #print "new codon ({}) is same as ref({}) at position {}".format(val, ref_aa_seq_np[key], key)
 
@@ -82,6 +81,7 @@ def translate_vcf_feature(sequences, ref, feature):
                 prot['positions'].append(key)
 
         #IF we wanted to get full translation....
+        #ref_aa_seq_np = np.array(list(ref_aa_seq), 'S1')
         #newAA = ref_aa_seq_np.copy()
         #newAA[aaRepLocs.keys()] = aaRepLocs.values()
 

--- a/tb/tb_snake
+++ b/tb/tb_snake
@@ -43,13 +43,14 @@ rule translate:
 
 rule mugration:
 	input:
-		"zika/results/tree.nwk"
+		"tb/results/tree.nwk",
+		"tb/results/tree.tsv"
 	output:
-		"zika/results/region_gtr.txt",
-		"zika/results/country_gtr.txt"
+		"tb/results/region_gtr.txt",
+		"tb/results/country_gtr.txt"
 	shell:
-		"python src/mugration.py --path zika --field country  &&"
-		"python src/mugration.py --path zika --field region"
+		"python src/mugration.py --path tb --field country  &&"
+		"python src/mugration.py --path tb --field region"
 
 rule export:
 	input:


### PR DESCRIPTION
Removing ref_aa_seq_np from translate.py, and trailing whitespace from util.py (this wasn't entirely intentional but should be done at some point anyway...)

Mugration has been tested and works as-is for VCF-style input