### PR TITLE
DRM ID & Colouring, Exclude Gaps from Auspice

### DIFF
--- a/src/build_tree.py
+++ b/src/build_tree.py
@@ -39,7 +39,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
 
 
 def build_iqtree(aln_file, out_file, iqmodel, clean_up=True, nthreads=2):
-    #return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick')
+    #return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
     if iqmodel:
         call = ["iqtree", "-nt", str(nthreads), "-s", aln_file, "-m", iqmodel[0],
             ">", "iqtree.log"]
@@ -84,7 +84,6 @@ def timetree(tree=None, aln=None, ref=None, seq_meta=None, keeproot=False,
     else:
         marginal = confidence
 
-    #tt.run(infer_gtr=infer_gtr, root="G20039", Tc=Tc, time_marginal=marginal, fixed_clock_rate=0.00000364,
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
            resolve_polytomies=resolve_polytomies, max_iter=max_iter, **kwarks)
 

--- a/src/build_tree.py
+++ b/src/build_tree.py
@@ -39,6 +39,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
 
 
 def build_iqtree(aln_file, out_file, iqmodel, clean_up=True, nthreads=2):
+    #return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick')
     if iqmodel:
         call = ["iqtree", "-nt", str(nthreads), "-s", aln_file, "-m", iqmodel[0],
             ">", "iqtree.log"]
@@ -83,6 +84,7 @@ def timetree(tree=None, aln=None, ref=None, seq_meta=None, keeproot=False,
     else:
         marginal = confidence
 
+    #tt.run(infer_gtr=infer_gtr, root="G20039", Tc=Tc, time_marginal=marginal, fixed_clock_rate=0.00000364,
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
            resolve_polytomies=resolve_polytomies, max_iter=max_iter, **kwarks)
 
@@ -162,12 +164,17 @@ def write_out_variable_fasta(compress_seq, path, drmfile=None):
             except KeyError, e:
                 pattern.append(ref[key])
         #pattern = [ sequences[k][key] if key in sequences[k].keys() else ref[key] for k,v in sequences.iteritems() ]
+        origPattern = list(pattern)
+        if '-' in pattern:
+            pattern = [value for value in origPattern if value != '-']
+            #remove gaps to see if otherwise non-variable
+            #print pattern
         un = np.unique(pattern, return_counts=True)
-        if len(un[0])==2 and min(un[1])==1: #'singleton' mutation - only happens in 1 seq
+        if len(un[0])==1 or (len(un[0])==2 and min(un[1])==1): #'singleton' mutation - only happens in 1 seq
         #if len(un[0])==1: #don't write out identical bases
             False #don't append! (python makes me put something here)
         else:
-            sites.append(pattern)
+            sites.append(origPattern) #append original with gaps (if present)
 
     #rotate into an alignment and turn into list of SeqRecord to output easily
     sites = np.asarray(sites)
@@ -209,6 +216,10 @@ if __name__ == '__main__':
     parser.add_argument('--drm', type=str,
                         help="file of DRMs to exclude from inital tree-building")
 
+    #EBH 14 Feb 2018
+    parser.add_argument('--roottype', type=str, default="residual",
+                        help="type of rerooting. options are 'rsq', 'residual' (default), and 'oldest'")
+
     args = parser.parse_args()
     path = args.path
 
@@ -242,9 +253,9 @@ if __name__ == '__main__':
 
     start = time.time()
     if args.raxml:
-        T = build_raxml(treebuild_align, tree_newick(path), path)
+        T = build_raxml(treebuild_align, tree_newick(path), path, args.nthreads)
     elif args.iqtree:
-        T = build_iqtree(treebuild_align, tree_newick(path), args.iqmodel)
+        T = build_iqtree(treebuild_align, tree_newick(path), args.iqmodel, args.nthreads)
     else: #use fasttree - if add more options, put another check here
         T = build_fasttree(treebuild_align, tree_newick(path))
     end = time.time()
@@ -257,10 +268,10 @@ if __name__ == '__main__':
     if args.timetree:
         if args.vcf:
             tt = timetree(tree=T, aln=sequences, ref=ref, confidence=args.confidence,
-                          seq_meta=meta, reroot=None if args.keeproot else 'best', Tc=args.Tc)
+                          seq_meta=meta, reroot=None if args.keeproot else args.roottype, Tc=args.Tc, use_marginal=True)
         else:
             tt = timetree(tree=T, aln=ref_alignment(path), confidence=args.confidence,
-                          seq_meta=meta, reroot=None if args.keeproot else 'best', Tc=args.Tc)
+                          seq_meta=meta, reroot=None if args.keeproot else args.roottype, Tc=args.Tc)
 
         T = tt.tree
         fields.extend(['mutations', 'mutation_length', 'num_date', 'clock_length'])
@@ -282,7 +293,12 @@ if __name__ == '__main__':
         n.clade = clade_index
         clade_index+=1
 
-    Phylo.write(T, tree_newick(path), 'newick')
+    if args.vcf:
+        Phylo.write(T, tree_newick(path), 'newick', format_branch_length='%1.8f')
+        #This gives more digits to branch length which for small numbers
+        #means it's more than just 0 and 0.00001 in the Newick!
+    else:
+        Phylo.write(T, tree_newick(path), 'newick')
     meta_dic = collect_tree_meta_data(T, fields, args.vcf)
     write_tree_meta_data(path, meta_dic)
 

--- a/src/export_to_auspice.py
+++ b/src/export_to_auspice.py
@@ -46,6 +46,8 @@ def attach_tree_meta_data(T, node_meta):
     def parse_mutations(muts):
         allMut = muts.split(',') if type(muts) in [str, unicode] else ""
         realMut=[]
+        #This exclude gaps from displaying in Auspice. They're ignored, in
+        #treebuilding anyway, and clutter up display/prevent from seeing real ones
         for m in allMut:
             if '-' not in m:
                 realMut.append(m)

--- a/src/export_to_auspice.py
+++ b/src/export_to_auspice.py
@@ -2,7 +2,8 @@ import numpy as np
 from util import (read_sequence_meta_data, read_tree_meta_data,
                   get_genes_and_alignments, generic_argparse)
 from filenames import (tree_newick, tree_json, tree_sequence_alignment,
-                       sequence_json, diversity_json, color_maps, meta_json)
+                       sequence_json, diversity_json, color_maps, meta_json,
+                       drm_color_maps)
 from util import write_json, load_features, diversity_statistics, load_lat_long_defs
 from Bio import Phylo
 
@@ -43,7 +44,15 @@ def tree_to_json(node, extra_attr = []):
 
 def attach_tree_meta_data(T, node_meta):
     def parse_mutations(muts):
-        return muts.split(',') if type(muts) in [str, unicode] else ""
+        allMut = muts.split(',') if type(muts) in [str, unicode] else ""
+        realMut=[]
+        for m in allMut:
+            if '-' not in m:
+                realMut.append(m)
+        if len(realMut)==0:
+            realMut = [""]
+        return realMut
+        #return muts.split(',') if type(muts) in [str, unicode] else ""
 
     for n in T.find_clades(order='preorder'):
         n.attr={}
@@ -129,6 +138,17 @@ def export_metadata_json(T, path, prefix, reference, isvcf=False, indent=1):
             except:
                 continue
             cmaps[trait].append((name, color))
+
+    #if drug-resistance colours have been auto-generated, get these too
+    import os.path
+    if os.path.isfile(drm_color_maps(path)):
+        with open(drm_color_maps(path), 'r') as cfile:
+            for line in cfile:
+                try:
+                    trait, name, color = line.strip().split('\t')
+                except:
+                    continue
+                cmaps[trait].append((name, color))
 
     mjson["color_options"] = {
       "gt": {

--- a/src/filenames.py
+++ b/src/filenames.py
@@ -91,6 +91,10 @@ def translation_ref_file(path):
     return path+'/results/'+'translation_reference.fasta'
 
 
+#EBH 13 Feb 18
+def drm_color_maps(path):
+    return path+'/results/'+'drm_color.tsv'
+
 #######################################
 # Auspice json file name
 #######################################

--- a/src/find_drm.py
+++ b/src/find_drm.py
@@ -1,0 +1,187 @@
+#EBH 15 Feb 2018
+#Identifies DRMs in VCF-files and writes them into tree_meta file.
+#Also creates colours for them and write them to a new drm_color file which is
+#later included in export_to_auspice if it exists
+
+import numpy as np
+import colorsys
+from util import read_tree_meta_data, write_tree_meta_data, read_in_vcf, generic_argparse
+from filenames import tree_vcf_alignment, ref_fasta, tree_meta_file_name, drm_color_maps
+
+
+def read_in_DRMs(drm_file):
+    import pandas as pd
+
+    DRMs = {}
+    drmPositions = []
+
+    df = pd.read_csv(drm_file, sep='\t')
+    for mi, m in df.iterrows():
+        pos = m.GENOMIC_POSITION-1 #put in python numbering
+        drmPositions.append(pos)
+
+        if pos in DRMs:
+            DRMs[pos]['base'].append(m.ALT_BASE)
+            DRMs[pos]['AA'].append(m.SUBSTITUTION)
+        else:
+            DRMs[pos] = {}
+            DRMs[pos]['base'] = [m.ALT_BASE]
+            DRMs[pos]['drug'] = m.DRUG
+            DRMs[pos]['AA'] = [m.SUBSTITUTION]
+            DRMs[pos]['gene'] = m.GENE
+
+    drmPositions = np.array(drmPositions)
+    drmPositions = np.unique(drmPositions)
+    drmPositions = np.sort(drmPositions)
+
+    DRM_info = {'DRMs': DRMs,
+            'drmPositions': drmPositions}
+
+    return DRM_info
+
+
+def drugTranslate(x):
+    return {
+        'RIF': 'Rifampicin',
+        'FQ': 'Fluoroquinolones',
+        'ETH': 'Ethionamide',
+        'EMB': 'Ethambutol',
+        'SM': 'Streptomycin',
+        'PZA': 'Pyrazinamide',
+        'CAP': 'Capreomycin',
+        'INH': 'Isoniazid',
+        'KAN': 'Kanamycin',
+        'AK': 'Amikacin'
+    }[x]
+
+
+def get_N_HexCol(n=5):
+    #modified from kquinn's answer on stackoverflow:
+    #https://stackoverflow.com/questions/876853/generating-color-ranges-in-python
+    import colorsys
+
+    HSV_tuples = [(x*1.0/n, 0.7, 0.7) for x in xrange(n)]
+    hex_out = []
+    for rgb in HSV_tuples:
+        rgb = map(lambda x: int(x*255),colorsys.hsv_to_rgb(*rgb))
+        hex_out.append("#"+"".join(map(lambda x: chr(x).encode('hex'),rgb)))
+    return hex_out
+
+
+def find_drms(DRM_info, sequences):
+    drmPositions = DRM_info['drmPositions']
+    DRMs = DRM_info['DRMs']
+
+    seqDRM = {}
+    for key in drmPositions:
+        for seq,v in sequences.iteritems():
+            try:
+                base = sequences[seq][key]
+                if base in DRMs[key]['base']:
+                    if seq not in seqDRM:
+                        seqDRM[seq] = {}
+
+                    i=0
+                    while base != DRMs[key]['base'][i]:
+                        i+=1
+                    seqDRM[seq][DRMs[key]['AA'][i]] = DRMs[key]['drug']
+
+            except KeyError, e:
+                continue
+
+    return seqDRM
+
+
+def remove_old_DRM(tree_met):
+    tree_met.pop('Rifampicin', None)
+    tree_met.pop('Fluoroquinolones', None)
+    tree_met.pop('Ethionamide', None)
+    tree_met.pop('Ethambutol', None)
+    tree_met.pop('Streptomycin', None)
+    tree_met.pop('Pyrazinamide', None)
+    tree_met.pop('Capreomycin', None)
+    tree_met.pop('Isoniazid', None)
+    tree_met.pop('Kanamycin', None)
+    tree_met.pop('Amikacin', None)
+    tree_met.pop('Drug_Resistance', None)
+
+
+def add_drm_tree_meta(path, seqDRM):
+    tree_meta = read_tree_meta_data(path)
+
+    #add drug resistance to tree_meta, & make list for colouring
+    drugMuts = {}
+    drugMuts["Drug_Resistance"] = ['0']
+    for seq,v in seqDRM.iteritems():
+        #in case re-running, don't add mutations to old ones!
+        remove_old_DRM(tree_meta[seq])
+        tempList = {}
+        for mut,drug in v.iteritems():
+            drugs = drug.split(';')
+            for drug in drugs:
+                trDrug = drugTranslate(drug)
+                if trDrug in tree_meta[seq]:
+                    tree_meta[seq][trDrug] = ",".join([tree_meta[seq][trDrug],mut])
+                else:
+                    tree_meta[seq][trDrug] = mut
+
+                if trDrug in drugMuts:
+                    if tree_meta[seq][trDrug] not in drugMuts[trDrug]:
+                        drugMuts[trDrug].append(tree_meta[seq][trDrug])
+                else:
+                    drugMuts[trDrug] = [ tree_meta[seq][trDrug] ]
+
+                tempList[trDrug] = ""
+
+        numResist = str(len(tempList))
+        tree_meta[seq]["Drug_Resistance"] = numResist
+        if numResist not in drugMuts["Drug_Resistance"]:
+            drugMuts["Drug_Resistance"].append(numResist)
+
+    #for any with no resistance, add a 0 to tree_meta
+    for seq,v in tree_meta.iteritems():
+        if 'Drug_Resistance' not in tree_meta[seq]:
+            tree_meta[seq]["Drug_Resistance"] = '0'
+
+    write_tree_meta_data(path, tree_meta)
+
+    return drugMuts
+
+
+if __name__ == '__main__':
+    parser =  generic_argparse("Find drug resistance mutations according to supplied file. ONLY WORKS FOR VCF FILES.")
+    parser.add_argument('--drm', type=str,
+                        help="file of DRMs to find")
+
+    args = parser.parse_args()
+    path = args.path
+
+    compress_seq = read_in_vcf(tree_vcf_alignment(path), ref_fasta(path), compressed=False)
+
+    sequences = compress_seq['sequences']
+    positions = compress_seq['positions']
+    ref = compress_seq['reference']
+
+    DRM_info = read_in_DRMs(args.drm)
+
+    #Find the DRMs and store them
+    seqDRM = find_drms(DRM_info, sequences)
+
+    #Add DRMs to the tree_meta file, and also collect all unique options/combos sort
+    #we can colour them
+    drugMuts = add_drm_tree_meta(path, seqDRM)
+
+    #Get colours and write them to a new color file that will be checked
+    #in export_to_auspice and included in meta.json if present
+    newColAdds = []
+    drugMuts["Drug_Resistance"].sort()
+    for drug,muts in drugMuts.iteritems():
+        cols = get_N_HexCol(len(muts))
+        drugCol = [ "\t".join([drug, muts[i], cols[i]]) for i in xrange(len(muts)) ]
+        drugCol.append("")
+        newColAdds = newColAdds + drugCol
+
+    with open(drm_color_maps(path), 'w') as the_file:
+        the_file.write("\n".join(newColAdds))
+
+

--- a/src/util.py
+++ b/src/util.py
@@ -27,7 +27,7 @@ def read_sequence_meta_data(path):
     from filenames import meta_file_name
     import pandas as pd
     df = pd.read_csv(meta_file_name(path), sep='\t').fillna('')
-    #import ipdb; ipdb.set_trace()
+    #reads blanks in TSV as blanks, which plays nice with TreeTime
     return {m[0]:m.to_dict() for mi, m in df.iterrows()}
 
 
@@ -584,6 +584,8 @@ def write_VCF_style_alignment(tree_dict, file_name):
                         pattern.append(ref[pi])
                 pattern = np.array(pattern)
                 #pattern = np.array([ sequences[k][pi] if pi in sequences[k].keys() else ref[pi] for k,v in sequences.iteritems() ])
+                #This stops 'greedy' behaviour from putting mutations that happen to be
+                #next to deletions on the same line/position as deletions.
                 if any(pattern == '-'): #if part of deletion, append
                     sites.append(pattern)
                     refb = refb+ref[pi]


### PR DESCRIPTION
Including some other minor changes as well.

**Build_tree.py**
- In writing out variable sites, sites that are only variable because of gaps are ignored
- `--roottype` is now an argument so user can specify the rooting from the call/snakemake
- `nthreads` argument is now actually passed to `build_raxml` and `build_iqtree`
- VCF TreeTime runs use `use_marginal` now
- In VCF runs, when writing out the phylogeny, branch lengths are printed with more decimal places, to allow seeing small differences

**Export_to_auspice.py**
- Mutations to/from gaps are now excluded from the Auspice JSON. Gaps are excluded in tree-building and they tend to just obscure meaningful nucleotide mutations and falsely inflate # of mutations on branches
- Automatically checks for the prensense of a colour file generated by finding DRM mutations in `find_drm.py`. If present, includes in the JSON


**Filenames.py**
- New path to location of DRM colours file generated by running `find_drm.py`

**Find_drm.py**
- New script that finds DRM mutations read in from a reference file on tip and ancestral sequences
- Adds them to the tree meta data, and generates colours for display in Auspice

**Util.py**
- `read_sequence_meta_data` now reads blanks in the TSV file as empty strings. This works better with TreeTime during mugration
- In `write_VCF_style_alignment`, it no longer includes mutations that happen to be next to deletions on the same line/position as the deletions. (This doesn't affect the legitimacy of the VCF, but it's non-standard!)

