### PR TITLE
Re-export gaps, add DRM timing, don't show Identical AA Muts

### DIFF
--- a/src/build_tree.py
+++ b/src/build_tree.py
@@ -39,7 +39,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
 
 
 def build_iqtree(aln_file, out_file, iqmodel, clean_up=True, nthreads=2):
-    #return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
+    return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
     if iqmodel:
         call = ["iqtree", "-nt", str(nthreads), "-s", aln_file, "-m", iqmodel[0],
             ">", "iqtree.log"]
@@ -96,12 +96,16 @@ def timetree(tree=None, aln=None, ref=None, seq_meta=None, keeproot=False,
     if ref != None: #if VCF, fix pi
         pi = np.array([0.1618, 0.3188, 0.3176, 0.1618, 0.04]) #from real runs (Walker 2018)
 
+    #for lee 2015
+    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, #relaxed_clock={"slack":1e-8, "coupling":1e-8}, #fixed_clock_rate=1.3e-7,
+     #  resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
-           resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
+        resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
-
-
+    #for walker 2018
+    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, relaxed_clock={"slack":1e-6, "coupling":1e-6}, fixed_clock_rate=3.5e-7, #relaxed_clock={"slack":None, "coupling":None}, #fixed_clock_rate=0.000001,
+    #   resolve_polytomies=False, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
 
     for n in T.find_clades():

--- a/src/build_tree.py
+++ b/src/build_tree.py
@@ -39,7 +39,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
 
 
 def build_iqtree(aln_file, out_file, iqmodel, clean_up=True, nthreads=2):
-    return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
+    #return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
     if iqmodel:
         call = ["iqtree", "-nt", str(nthreads), "-s", aln_file, "-m", iqmodel[0],
             ">", "iqtree.log"]
@@ -96,16 +96,12 @@ def timetree(tree=None, aln=None, ref=None, seq_meta=None, keeproot=False,
     if ref != None: #if VCF, fix pi
         pi = np.array([0.1618, 0.3188, 0.3176, 0.1618, 0.04]) #from real runs (Walker 2018)
 
-    #for lee 2015
-    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, #relaxed_clock={"slack":1e-8, "coupling":1e-8}, #fixed_clock_rate=1.3e-7,
-     #  resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
         resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
-    #for walker 2018
-    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, relaxed_clock={"slack":1e-6, "coupling":1e-6}, fixed_clock_rate=3.5e-7, #relaxed_clock={"slack":None, "coupling":None}, #fixed_clock_rate=0.000001,
-    #   resolve_polytomies=False, max_iter=max_iter, fixed_pi=pi, **kwarks)
+
+
 
 
     for n in T.find_clades():
@@ -143,7 +139,8 @@ def export_sequence_fasta(T, path):
 
 def export_sequence_VCF(tt, path, var_ambigs=False):
     tree_dict = tt.get_tree_dict(var_ambigs)
-    write_VCF_style_alignment(tree_dict, tree_vcf_alignment(path,'nuc'))
+    #in new augur, set 'compress' based on input file ending!
+    write_VCF_style_alignment(tree_dict, tree_vcf_alignment(path,'nuc'), compress=False)
 
 
 def write_out_variable_fasta(compress_seq, path, drmfile=None):

--- a/src/export_to_auspice.py
+++ b/src/export_to_auspice.py
@@ -44,17 +44,7 @@ def tree_to_json(node, extra_attr = []):
 
 def attach_tree_meta_data(T, node_meta):
     def parse_mutations(muts):
-        allMut = muts.split(',') if type(muts) in [str, unicode] else ""
-        realMut=[]
-        #This exclude gaps from displaying in Auspice. They're ignored, in
-        #treebuilding anyway, and clutter up display/prevent from seeing real ones
-        for m in allMut:
-            if '-' not in m:
-                realMut.append(m)
-        if len(realMut)==0:
-            realMut = [""]
-        return realMut
-        #return muts.split(',') if type(muts) in [str, unicode] else ""
+        return muts.split(',') if type(muts) in [str, unicode] else ""
 
     for n in T.find_clades(order='preorder'):
         n.attr={}

--- a/src/find_drm.py
+++ b/src/find_drm.py
@@ -159,7 +159,7 @@ if __name__ == '__main__':
     import time
     start = time.time()
 
-    compress_seq = read_in_vcf(tree_vcf_alignment(path), ref_fasta(path), compressed=False)
+    compress_seq = read_in_vcf(tree_vcf_alignment(path), ref_fasta(path))
 
     sequences = compress_seq['sequences']
     positions = compress_seq['positions']

--- a/src/find_drm.py
+++ b/src/find_drm.py
@@ -156,6 +156,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
     path = args.path
 
+    import time
+    start = time.time()
+
     compress_seq = read_in_vcf(tree_vcf_alignment(path), ref_fasta(path), compressed=False)
 
     sequences = compress_seq['sequences']
@@ -184,4 +187,5 @@ if __name__ == '__main__':
     with open(drm_color_maps(path), 'w') as the_file:
         the_file.write("\n".join(newColAdds))
 
-
+    end = time.time()
+    print "DRM processing took {}".format(str(end-start))

--- a/src/translate.py
+++ b/src/translate.py
@@ -192,6 +192,7 @@ def get_amino_acid_mutations(tree, fname):
 def assign_amino_acid_muts_vcf(prots, path):
     tree_meta = read_tree_meta_data(path)
     seqNames = prots[prots.keys()[0]]['sequences'].keys()
+    excluded = []
 
     #go through every gene in the prots nested dict
     for fname, prot in prots.iteritems():
@@ -210,18 +211,29 @@ def assign_amino_acid_muts_vcf(prots, path):
 
             pattern = [ refb+str(pos)+sequences[k][pi] if pi in sequences[k].keys()
                         else "" for k,v in sequences.iteritems() ]
-            pats.append(pattern)
+
+            #if the exact same mutation in all sequences, don't include! (only mutant against ref..)
+            if not (len(pattern)==len(sequences) and len(np.unique(pattern))==1):
+                pats.append(pattern)
             i+=1
 
         #convert our list of lists to matrix
         patMat = np.matrix(pats)
 
-        #for every sequence, assign the mutations in tree_meta
-        for i in xrange(len(seqNames)):
-            node_name = seqNames[i]
-            ary = np.array(patMat[:,i]).reshape(-1,)
-            tree_meta[node_name][fname+'_mutations'] = ",".join(ary[ary != ''])
+        #don't include if all the mutations identical across sequences! (only mutant against ref..)
+        if len(pats) != 0:
+            #for every sequence, assign the mutations in tree_meta
+            for i in xrange(len(seqNames)):
+                node_name = seqNames[i]
+                ary = np.array(patMat[:,i]).reshape(-1,)
+                tree_meta[node_name][fname+'_mutations'] = ",".join(ary[ary != ''])
+        else:
+            excluded.append(fname)
 
+    if len(excluded) != 0:
+        print "{} genes do not differ across the tree. They will not be added to tree meta-data or shown in auspice".format(len(excluded))
+        
+            
     #write it out!
     write_tree_meta_data(path, tree_meta)
 

--- a/src/translate.py
+++ b/src/translate.py
@@ -114,7 +114,7 @@ def translate_vcf(vcf_fname, reference, path, feature_names=None):
     import time
     start = time.time()
     try:
-        vcf_dict = read_in_vcf(vcf_fname, ref_fasta(path), compressed=False )
+        vcf_dict = read_in_vcf(vcf_fname, ref_fasta(path))
     except:
         print "Loading input alignment failed!: {}".format(vcf_fname)
     end = time.time()
@@ -153,7 +153,8 @@ def translate_vcf(vcf_fname, reference, path, feature_names=None):
 
     start = time.time()
     #print out VCF of proteins
-    write_VCF_translation(prots, translation_vcf_file(path), translation_ref_file(path))
+    #in new augur, set compress depending on input file ending!
+    write_VCF_translation(prots, translation_vcf_file(path), translation_ref_file(path), compress=False)
     end = time.time()
     print "Writing out VCF took {}".format(str(end-start))
 
@@ -232,8 +233,8 @@ def assign_amino_acid_muts_vcf(prots, path):
 
     if len(excluded) != 0:
         print "{} genes do not differ across the tree. They will not be added to tree meta-data or shown in auspice".format(len(excluded))
-        
-            
+
+
     #write it out!
     write_tree_meta_data(path, tree_meta)
 

--- a/src/util.py
+++ b/src/util.py
@@ -88,7 +88,7 @@ def collect_tree_meta_data(T, fields, isvcf=False, meta=None):
 
     return meta
 
-def read_in_vcf(vcf_file, ref_file, compressed=True):
+def read_in_vcf(vcf_file, ref_file):
     """
     Reads in a vcf.gz file (or vcf if compressed is False) and associated
     reference sequence fasta (to which the VCF file is mapped)
@@ -169,7 +169,8 @@ def read_in_vcf(vcf_file, ref_file, compressed=True):
     altLoc = 0
     sampLoc = 9
 
-    if compressed: #must use 2 diff functions depending on compressed or not
+    #Use different openers depending on whether compressed
+    if vcf_file.endswith(('.gz', '.GZ')):
         opn = gzip.open
     else:
         opn = open
@@ -561,7 +562,7 @@ def write_json(data, file_name, indent=1):
         json.dump(data, handle, indent=indent)
         handle.close()
 
-def write_VCF_style_alignment(tree_dict, file_name):
+def write_VCF_style_alignment(tree_dict, file_name, compress=False):
     """
     Writes out a VCF-style file (which seems to be minimally handleable
     by vcftools and pyvcf) of the alignment from the input of a dict
@@ -754,6 +755,12 @@ def write_VCF_style_alignment(tree_dict, file_name):
     with open(file_name, 'a') as the_file:
         the_file.write("\n".join(vcfWrite))
 
+    if compress:
+        import os
+        call = ["gzip", file_name]
+        os.system(" ".join(call))
+
+
 
 ########################################
 # translation
@@ -914,7 +921,7 @@ def load_features(reference, feature_names=None):
     return features
 
 
-def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
+def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name, compress=False):
     """
     Writes out a VCF-style file (which seems to be minimally handleable
     by vcftools and pyvcf) of the AA differences between sequences and the reference.
@@ -990,6 +997,10 @@ def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
     with open(vcf_file_name, 'a') as the_file:
         the_file.write("\n".join(vcfWrite))
 
+    if compress:
+        import os
+        call = ["gzip", vcf_file_name]
+        os.system(" ".join(call))
 
 def load_lat_long_defs():
     places = {}


### PR DESCRIPTION
All minor edits, only the `translate.py` change will be relevant to incorporate into new augur

`export_to_auspice.py/attach_tree_meta_data` reverted to original code which exports all mutations, instead of excluding gaps. As `auspice` now modified to separate out 'N' and '-' mutations in display, all can be exported.

`find_drm.py` modified to add a timer (to bring in line with other scripts)

`translate.py/assign_amino_acid_muts_vcf` only writes AA mutations to the tree (which will be displayed in `auspice`) if they are not identical across the tree (this happens when the mutant against the reference, but not across the tree). This prevents the same AA mutation showing for every sequence.
However, these mutations **are** still written out in the psuedo-VCF file for AA mutations, as this continues to show the gene/site as mutant against the reference.